### PR TITLE
fix: Typo in reports and trades screens

### DIFF
--- a/src/app/reports/reports.component.html
+++ b/src/app/reports/reports.component.html
@@ -7,7 +7,7 @@
   <div class="col-auto form-group">
     <label for="account" class="mr-2">Account*</label>
     <select formControlName="account_id_eq" id="account" class="custom-select my-1 mr-4">
-      <option value="" [disabled]="true">Choose an acocunt</option>
+      <option value="" [disabled]="true">Choose an account</option>
       <option *ngFor="let account of accounts" value="{{account.id}}">{{account.broker.name}}
         - {{account.getAccountType()}}</option>
     </select>

--- a/src/app/trades/trades.component.html
+++ b/src/app/trades/trades.component.html
@@ -6,13 +6,10 @@
 <div class="form-inline">
   <label for="account-filter" class="my-1 mr-2 sr-only">Choose an account</label>
   <select (change)="goToTrades($event)" id="account-filter" class="custom-select my-1 mr-4">
-    <option value="" [disabled]="isDisabled">Choose an acocunt</option>
+    <option value="" [disabled]="isDisabled">Choose an account</option>
     <option *ngFor="let account of accounts" value="{{account.id}}" [selected]="router.url.endsWith(account.id.toString())">{{account.broker.name}}
       - {{account.getAccountType()}}</option>
   </select>
 </div>
 
 <router-outlet></router-outlet>
-
-
-


### PR DESCRIPTION
**Contains**
- [x]  Hotfix

**Changes**
- Fix typo: "Choose an acocunt" -> "Choose an account"
